### PR TITLE
Added support for interface and trait

### DIFF
--- a/CodeDoc.py
+++ b/CodeDoc.py
@@ -48,7 +48,7 @@ class CodedocEv(sublime_plugin.EventListener):
 			snippet = self.expandPhpFunction(declaration)
 			if snippet:
 				return [('/**', snippet)]
-		elif (declaration.find("class") or declaration.find("interface") or declaration.find("trait")) > -1:
+		elif (declaration.find("class") > -1 or declaration.find("interface") > -1 or declaration.find("trait") > -1):
 			snippet = self.expandPhpClass(declaration)
 			if snippet:
 				return [('/**', snippet)]

--- a/CodeDoc.py
+++ b/CodeDoc.py
@@ -48,7 +48,7 @@ class CodedocEv(sublime_plugin.EventListener):
 			snippet = self.expandPhpFunction(declaration)
 			if snippet:
 				return [('/**', snippet)]
-		elif declaration.find("class") > -1:
+		elif (declaration.find("class") or declaration.find("interface") or declaration.find("trait")) > -1:
 			snippet = self.expandPhpClass(declaration)
 			if snippet:
 				return [('/**', snippet)]
@@ -62,7 +62,6 @@ class CodedocEv(sublime_plugin.EventListener):
 	def expandPhpClass(self, declaration):
 		snippet = '/**\n'
 		snippet += ' * ${1}\n'
-		snippet += ' * @package ${2:default}\n'
 		snippet += ' */'
 		return snippet
 


### PR DESCRIPTION
@package default removed due to not being necessary

http://phpdoc.org/docs/latest/references/phpdoc/tags/package.html

> If, across the board, both logical and functional subdivisions are equal is it NOT RECOMMENDED to use the @package tag, to prevent maintenance overhead.
